### PR TITLE
issue18 - add formats for API and TFE_resource 

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ variable "docker_ports" {
     image_id = "abc"
   ```
 
-- You can use the `-w, -workspace` flag to out put all variables in the payload format for the API <https://www.terraform.io/docs/cloud/api/workspace-variables.html#sample-payload>
+-
+
+- The `-w, -workspace` flag outputs all variables in the payload format for the API <https://www.terraform.io/docs/cloud/api/workspace-variables.html#sample-payload>
 
 You can use `jq` to filter variables by key name.
 

--- a/README.md
+++ b/README.md
@@ -96,21 +96,19 @@ variable "docker_ports" {
     image_id = "abc"
   ```
 
--
+- The `-r, --resource` flag outputs all variables as terraform resources for the `tfe_variable resource` found in the `tfe` provider <https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable>
 
-- The `-w, -workspace` flag outputs all variables in the payload format for the API <https://www.terraform.io/docs/cloud/api/workspace-variables.html#sample-payload>
+- The `-w, --workspace` flag outputs all variables in the payload format for the API <https://www.terraform.io/docs/cloud/api/workspace-variables.html#sample-payload>.  You can use `jq` to filter variables by key name.
 
-You can use `jq` to filter variables by key name.
 
-```shell
-
-$ tfvar  -w pkg/tfvar/testdata/defaults/. | jq '. | select(.data.attributes.key == "region")'
-{
-	"data": {
-		...
-	}
-}
-```
+    ```shell
+    $ tfvar  -w pkg/tfvar/testdata/defaults/. | jq '. | select(.data.attributes.key == "region")'
+    {
+	   "data": {
+		   ...
+	   }
+    }
+    ```
 
 For more info, checkout the `--help` page:
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ variable "docker_ports" {
     image_id = "abc"
   ```
 
+- You can use the `-w, -workspace` flag to out put all variables in the payload format for the API <https://www.terraform.io/docs/cloud/api/workspace-variables.html#sample-payload>
+
+You can use `jq` to filter variables by key name.
+
+```shell
+
+./tfvar  -w pkg/tfvar/testdata/defaults/. | jq '. | select(.data.attributes.key == "region")'
+```
 For more info, checkout the `--help` page:
 
 ```
@@ -113,11 +121,13 @@ Flags:
   -e, --env-var                Print output in export TF_VAR_image_id=ami-abc123 format
   -h, --help                   help for tfvar
       --ignore-default         Do not use defined default values
+  -r, --resource               Print output in hashicorp/tfe tfe_variable resource format
       --var stringArray        Set a variable in the generated definitions.
                                This flag can be set multiple times.
       --var-file stringArray   Set variables from a file.
                                This flag can be set multiple times.
   -v, --version                version for tfvar
+  -w, --workspace              Print output variables as payloads for workspace API
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,14 @@ You can use `jq` to filter variables by key name.
 
 ```shell
 
-./tfvar  -w pkg/tfvar/testdata/defaults/. | jq '. | select(.data.attributes.key == "region")'
+$ tfvar  -w pkg/tfvar/testdata/defaults/. | jq '. | select(.data.attributes.key == "region")'
+{
+	"data": {
+		...
+	}
+}
 ```
+
 For more info, checkout the `--help` page:
 
 ```

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -16,8 +16,10 @@ const (
 	flagDebug      = "debug"
 	flagEnvVar     = "env-var"
 	flagNoDefault  = "ignore-default"
+	flagResource   = "resource"
 	flagVar        = "var"
 	flagVarFile    = "var-file"
+	flagWorkspace  = "workspace"
 )
 
 // New returns a new instance of cobra.Command for tfvar. Usage:
@@ -49,6 +51,8 @@ one would write it in variable definitions files (.tfvars).
 variable definitions files e.g. terraform.tfvars[.json] *.auto.tfvars[.json]`)
 	rootCmd.PersistentFlags().BoolP(flagDebug, "d", false, "Print debug log on stderr")
 	rootCmd.PersistentFlags().BoolP(flagEnvVar, "e", false, "Print output in export TF_VAR_image_id=ami-abc123 format")
+	rootCmd.PersistentFlags().BoolP(flagResource, "r", false, "Print output in hashicorp/tfe tfe_variable resource format")
+	rootCmd.PersistentFlags().BoolP(flagWorkspace, "w", false, "Print output variables as payloads for workspace API")
 	rootCmd.PersistentFlags().Bool(flagNoDefault, false, "Do not use defined default values")
 	rootCmd.PersistentFlags().StringArray(flagVar, []string{}, `Set a variable in the generated definitions.
 This flag can be set multiple times.`)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -126,6 +126,15 @@ func (r *runner) rootRunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.Wrap(err, "cmd: get flag --auto-assign")
 	}
+	isWorkspace, err := cmd.PersistentFlags().GetBool(flagWorkspace)
+	if err != nil {
+		return errors.Wrap(err, "cmd: get flag --workspace")
+	}
+
+	isResource, err := cmd.PersistentFlags().GetBool(flagResource)
+	if err != nil {
+		return errors.Wrap(err, "cmd: get flag --resource")
+	}
 
 	unparseds := make(map[string]tfvar.UnparsedVariableValue)
 
@@ -176,5 +185,14 @@ func (r *runner) rootRunE(cmd *cobra.Command, args []string) error {
 		writer = tfvar.WriteAsEnvVars
 	}
 
+	if isWorkspace {
+		r.log.Debug("Print outputs in Workspace API payload format")
+		writer = tfvar.WriteAsWorkspacePayload
+	}
+
+	if isResource {
+		r.log.Debug("Print outputs in tfe_resource format")
+		writer = tfvar.WriteAsTFE_Resource
+	}
 	return writer(r.out, vars)
 }

--- a/pkg/tfvar/tfvar.go
+++ b/pkg/tfvar/tfvar.go
@@ -142,7 +142,7 @@ func WriteAsWorkspacePayload(w io.Writer, vars []Variable) error {
 		`, v.Name, string(b), v.Description, "terraform", "false", v.Sensitive)
 		if payload == nil {
 			_, err := fmt.Fprintf(w, "%s", data)
-			payload = errors.Wrap(err, "tfvar: unexpected writing payload")
+			payload = errors.Wrap(err, "tfvar: unexpected error writing payload")
 		}
 	}
 

--- a/pkg/tfvar/tfvar.go
+++ b/pkg/tfvar/tfvar.go
@@ -140,7 +140,7 @@ func WriteAsWorkspacePayload(w io.Writer, vars []Variable) error {
 				}
 			}
 		}
-		`, v.Name, string(b), v.Description, "terraform", "true", "false")
+		`, v.Name, string(b), v.Description, "terraform", "false", "false")
 		if payload == nil {
 			_, err := fmt.Fprintf(w, "%s", data)
 			payload = errors.Wrap(err, "tfvar: unexpected writing payload")

--- a/pkg/tfvar/tfvar.go
+++ b/pkg/tfvar/tfvar.go
@@ -115,8 +115,7 @@ func WriteAsTFVars(w io.Writer, vars []Variable) error {
 	return errors.Wrap(err, "tfvar: failed to write as tfvars")
 }
 func WriteAsWorkspacePayload(w io.Writer, vars []Variable) error {
-	var payload error
-
+	var data error
 	for _, v := range vars {
 		val := convertNull(v.Value)
 
@@ -140,13 +139,12 @@ func WriteAsWorkspacePayload(w io.Writer, vars []Variable) error {
 			}
 		}
 		`, v.Name, string(b), v.Description, "terraform", "false", v.Sensitive)
-		if payload == nil {
-			_, err := fmt.Fprintf(w, "%s", data)
-			payload = errors.Wrap(err, "tfvar: unexpected error writing payload")
+		if _, err := fmt.Fprintf(w, "%s", data); err != nil {
+			return errors.Wrap(err, "tfvar: unexpected error writing payload")
 		}
-	}
 
-	return payload
+	}
+	return data
 }
 func WriteAsTFE_Resource(w io.Writer, vars []Variable) error {
 	f := hclwrite.NewEmptyFile()

--- a/pkg/tfvar/tfvar.go
+++ b/pkg/tfvar/tfvar.go
@@ -135,7 +135,7 @@ func WriteAsWorkspacePayload(w io.Writer, vars []Variable) error {
 					"description": "%s",
 					"category":    "%s",
 					"hcl":         %s,
-					"sensitive":   %s
+					"sensitive":   %v
 				}
 			}
 		}

--- a/pkg/tfvar/tfvar.go
+++ b/pkg/tfvar/tfvar.go
@@ -157,6 +157,7 @@ func WriteAsTFE_Resource(w io.Writer, vars []Variable) error {
 		rootBody.AppendNewline()
 		resourceBlock := rootBody.AppendNewBlock("resource", []string{"tfe_variable", v.Name})
 		resourceBody := resourceBlock.Body()
+		resourceBody.SetAttributeValue("key", cty.StringVal(v.Name))
 		resourceBody.SetAttributeValue("value", v.Value)
 		resourceBody.SetAttributeValue("sensitive", cty.BoolVal(false))
 		resourceBody.SetAttributeValue("description", cty.StringVal(v.Description))

--- a/pkg/tfvar/tfvar.go
+++ b/pkg/tfvar/tfvar.go
@@ -21,6 +21,7 @@ type Variable struct {
 	Name        string
 	Value       cty.Value
 	Description string
+	Sensitive   bool
 
 	parsingMode configs.VariableParsingMode
 }
@@ -41,6 +42,7 @@ func Load(dir string) ([]Variable, error) {
 			Name:        v.Name,
 			Value:       v.Default,
 			Description: v.Description,
+			Sensitive:   v.Sensitive,
 
 			parsingMode: v.ParsingMode,
 		})
@@ -137,7 +139,7 @@ func WriteAsWorkspacePayload(w io.Writer, vars []Variable) error {
 				}
 			}
 		}
-		`, v.Name, string(b), v.Description, "terraform", "false", "false")
+		`, v.Name, string(b), v.Description, "terraform", "false", v.Sensitive)
 		if payload == nil {
 			_, err := fmt.Fprintf(w, "%s", data)
 			payload = errors.Wrap(err, "tfvar: unexpected writing payload")
@@ -156,7 +158,7 @@ func WriteAsTFE_Resource(w io.Writer, vars []Variable) error {
 		resourceBody := resourceBlock.Body()
 		resourceBody.SetAttributeValue("key", cty.StringVal(v.Name))
 		resourceBody.SetAttributeValue("value", v.Value)
-		resourceBody.SetAttributeValue("sensitive", cty.BoolVal(false))
+		resourceBody.SetAttributeValue("sensitive", cty.BoolVal(v.Sensitive))
 		resourceBody.SetAttributeValue("description", cty.StringVal(v.Description))
 		resourceBody.SetAttributeValue("workspace_id", cty.NilVal)
 		resourceBody.SetAttributeValue("category", cty.StringVal("terraform"))

--- a/pkg/tfvar/tfvar.go
+++ b/pkg/tfvar/tfvar.go
@@ -117,7 +117,20 @@ func WriteAsWorkspacePayload(w io.Writer, vars []Variable) error {
 	rootBody := f.Body()
 
 	for _, v := range vars {
-		rootBody.SetAttributeValue(v.Name, v.Value)
+		json := rootBody.AppendNewBlock("", nil)
+		jsonBody := json.Body()
+		dataBlock := jsonBody.AppendNewBlock("data", nil)
+		dataBody := dataBlock.Body()
+		dataBody.SetAttributeValue("type", cty.StringVal("vars"))
+		attBlock := dataBody.AppendNewBlock("Attributes", nil)
+		attBody := attBlock.Body()
+		attBody.SetAttributeValue("key", cty.StringVal(v.Name))
+		attBody.SetAttributeValue("value", v.Value)
+		attBody.SetAttributeValue("description", cty.StringVal(v.Description))
+		attBody.SetAttributeValue("category", cty.StringVal("terraform"))
+		attBody.SetAttributeValue("hcl", cty.BoolVal(false))
+		attBody.SetAttributeValue("sensitive", cty.BoolVal(false))
+		rootBody.AppendNewline()
 	}
 
 	_, err := f.WriteTo(w)

--- a/pkg/tfvar/tfvar_test.go
+++ b/pkg/tfvar/tfvar_test.go
@@ -98,3 +98,162 @@ region        = null
 `
 	assert.Equal(t, expected, buf.String())
 }
+func TestWriteAsTFE_Resource(t *testing.T) {
+	vars, err := Load("testdata/defaults")
+	require.NoError(t, err)
+
+	sort.Slice(vars, func(i, j int) bool { return vars[i].Name < vars[j].Name })
+
+	var buf bytes.Buffer
+	assert.NoError(t, WriteAsTFE_Resource(&buf, vars))
+
+	expected := `
+resource "tfe_variable" "availability_zone_names" {
+  value        = ["us-west-1a"]
+  sensitive    = false
+  description  = ""
+  workspace_id = null
+  category     = "terraform"
+}
+
+resource "tfe_variable" "aws_amis" {
+  value = {
+    eu-west-1 = "ami-b1cf19c6"
+    us-east-1 = "ami-de7ab6b6"
+    us-west-1 = "ami-3f75767a"
+    us-west-2 = "ami-21f78e11"
+  }
+  sensitive    = false
+  description  = ""
+  workspace_id = null
+  category     = "terraform"
+}
+
+resource "tfe_variable" "docker_ports" {
+  value = [{
+    external = 8300
+    internal = 8301
+    protocol = "tcp"
+  }]
+  sensitive    = false
+  description  = ""
+  workspace_id = null
+  category     = "terraform"
+}
+
+resource "tfe_variable" "instance_name" {
+  value        = "my-instance"
+  sensitive    = false
+  description  = ""
+  workspace_id = null
+  category     = "terraform"
+}
+
+resource "tfe_variable" "password" {
+  value        = null
+  sensitive    = false
+  description  = "the root password to use with the database"
+  workspace_id = null
+  category     = "terraform"
+}
+
+resource "tfe_variable" "region" {
+  value        = null
+  sensitive    = false
+  description  = ""
+  workspace_id = null
+  category     = "terraform"
+}
+`
+	assert.Equal(t, expected, buf.String())
+}
+func TestWriteAsWorkspacePayload(t *testing.T) {
+	vars, err := Load("testdata/defaults")
+	require.NoError(t, err)
+
+	sort.Slice(vars, func(i, j int) bool { return vars[i].Name < vars[j].Name })
+
+	var buf bytes.Buffer
+	assert.NoError(t, WriteAsWorkspacePayload(&buf, vars))
+
+	expected := `{
+			"data": {
+				"type": "vars",
+				"attributes": {
+					"key":         "availability_zone_names",
+					"value":       "['us-west-1a']",
+					"description": "",
+					"category":    "terraform",
+					"hcl":         false,
+					"sensitive":   false
+				}
+			}
+		}
+		{
+			"data": {
+				"type": "vars",
+				"attributes": {
+					"key":         "aws_amis",
+					"value":       "{ eu-west-1 = 'ami-b1cf19c6', us-east-1 = 'ami-de7ab6b6', us-west-1 = 'ami-3f75767a', us-west-2 = 'ami-21f78e11' }",
+					"description": "",
+					"category":    "terraform",
+					"hcl":         false,
+					"sensitive":   false
+				}
+			}
+		}
+		{
+			"data": {
+				"type": "vars",
+				"attributes": {
+					"key":         "docker_ports",
+					"value":       "[{ external = 8300, internal = 8301, protocol = 'tcp' }]",
+					"description": "",
+					"category":    "terraform",
+					"hcl":         false,
+					"sensitive":   false
+				}
+			}
+		}
+		{
+			"data": {
+				"type": "vars",
+				"attributes": {
+					"key":         "instance_name",
+					"value":       "my-instance",
+					"description": "",
+					"category":    "terraform",
+					"hcl":         false,
+					"sensitive":   false
+				}
+			}
+		}
+		{
+			"data": {
+				"type": "vars",
+				"attributes": {
+					"key":         "password",
+					"value":       "",
+					"description": "the root password to use with the database",
+					"category":    "terraform",
+					"hcl":         false,
+					"sensitive":   false
+				}
+			}
+		}
+		{
+			"data": {
+				"type": "vars",
+				"attributes": {
+					"key":         "region",
+					"value":       "",
+					"description": "",
+					"category":    "terraform",
+					"hcl":         false,
+					"sensitive":   false
+				}
+			}
+		}
+		`
+	assert.Equal(t, expected, buf.String())
+}

--- a/pkg/tfvar/tfvar_test.go
+++ b/pkg/tfvar/tfvar_test.go
@@ -109,6 +109,7 @@ func TestWriteAsTFE_Resource(t *testing.T) {
 
 	expected := `
 resource "tfe_variable" "availability_zone_names" {
+  key          = "availability_zone_names"
   value        = ["us-west-1a"]
   sensitive    = false
   description  = ""
@@ -117,6 +118,7 @@ resource "tfe_variable" "availability_zone_names" {
 }
 
 resource "tfe_variable" "aws_amis" {
+  key = "aws_amis"
   value = {
     eu-west-1 = "ami-b1cf19c6"
     us-east-1 = "ami-de7ab6b6"
@@ -130,6 +132,7 @@ resource "tfe_variable" "aws_amis" {
 }
 
 resource "tfe_variable" "docker_ports" {
+  key = "docker_ports"
   value = [{
     external = 8300
     internal = 8301
@@ -142,6 +145,7 @@ resource "tfe_variable" "docker_ports" {
 }
 
 resource "tfe_variable" "instance_name" {
+  key          = "instance_name"
   value        = "my-instance"
   sensitive    = false
   description  = ""
@@ -150,6 +154,7 @@ resource "tfe_variable" "instance_name" {
 }
 
 resource "tfe_variable" "password" {
+  key          = "password"
   value        = null
   sensitive    = false
   description  = "the root password to use with the database"
@@ -158,6 +163,7 @@ resource "tfe_variable" "password" {
 }
 
 resource "tfe_variable" "region" {
+  key          = "region"
   value        = null
   sensitive    = false
   description  = ""

--- a/pkg/tfvar/tfvar_test.go
+++ b/pkg/tfvar/tfvar_test.go
@@ -156,7 +156,7 @@ resource "tfe_variable" "instance_name" {
 resource "tfe_variable" "password" {
   key          = "password"
   value        = null
-  sensitive    = false
+  sensitive    = true
   description  = "the root password to use with the database"
   workspace_id = null
   category     = "terraform"
@@ -243,7 +243,7 @@ func TestWriteAsWorkspacePayload(t *testing.T) {
 					"description": "the root password to use with the database",
 					"category":    "terraform",
 					"hcl":         false,
-					"sensitive":   false
+					"sensitive":   true
 				}
 			}
 		}


### PR DESCRIPTION
# Related Issue

see https://github.com/shihanng/tfvar/issues/18

# Description

- Added format output for tfe_variable resource
- Added format output for tfe/c workspace variable api

# todo
please check all the relevant components;

- [x] Syntax review
- [ ] I don't understand pre-commit validation __HELP__ (You have read the ./contributors.md in the project)
- [x] Code review && test
- [ ] Something else see How To

# How to

How to Test, please include some steps and some expected outputs with context.
How to what every else you expect

```
make lint
make test
make tfvar

# run local tfvar and review help flags (-r,-w)
./tfvar -help 
# to test tfe_resource output 
./tfvar -r pkg/tfvar/testdata/defaults/.

# to test api output
./tfvar -w pkg/tfvar/testdata/defaults/.

#cherry picking variables for the api payload is left as an exercise for the reader. 
# hint: jq filters example included in README.md



