### PR TITLE
README: add MacPorts install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ Flags:
 brew install shihanng/tfvar/tfvar
 ```
 
+### [MacPorts (macOS)](https://ports.macports.org/port/tfvar/)
+
+```
+sudo port install tfvar
+```
+
 ### Debian, Ubuntu
 
 ```


### PR DESCRIPTION
`tfvar` has been added to MacPorts: https://ports.macports.org/port/tfvar/