### PR TITLE
support for 'import' blocks in terraform v1.5.x

### DIFF
--- a/pkg/configs/parser_config.go
+++ b/pkg/configs/parser_config.go
@@ -60,6 +60,7 @@ func (p *Parser) loadConfigFile(path string, override bool) (*File, hcl.Diagnost
 		case "resource":
 		case "data":
 		case "moved":
+		case "import":
 		default:
 			// Should never happen because the above cases should be exhaustive
 			// for all block type names in our schema.
@@ -114,6 +115,9 @@ var configFileSchema = &hcl.BodySchema{
 		},
 		{
 			Type: "moved",
+		},
+		{
+			Type: "import",
 		},
 	},
 }

--- a/pkg/tfvar/testdata/normal/main.tf
+++ b/pkg/tfvar/testdata/normal/main.tf
@@ -12,3 +12,8 @@ moved {
   from = aws_instance.a
   to   = aws_instance.b
 }
+
+import {
+  id = "i-123545"
+  to = aws_instance.b
+}


### PR DESCRIPTION
RE: https://github.com/shihanng/tfvar/issues/29

Terraform v1.5.x introduced the `import` block. This change adds the name of this block type to be expected