### PR TITLE
return exit code 1 when command line errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,9 @@ var version = "dev"
 
 func main() {
 	c, sync := cmd.New(os.Stdout, version)
-	_ = c.Execute()
+	defer sync()
 
-	sync()
+	if err := c.Execute(); err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Before:
```
$ go run main.go > /dev/null; echo $?
0
```
After:
```
$ go run main.go > /dev/null
exit status 1
```