### PR TITLE
Support for 'removed' blocks in terraform v1.7.x

### DIFF
--- a/pkg/configs/parser_config.go
+++ b/pkg/configs/parser_config.go
@@ -119,5 +119,8 @@ var configFileSchema = &hcl.BodySchema{
 		{
 			Type: "import",
 		},
+		{
+			Type: "removed",
+		},
 	},
 }

--- a/pkg/tfvar/testdata/normal/main.tf
+++ b/pkg/tfvar/testdata/normal/main.tf
@@ -17,3 +17,11 @@ import {
   id = "i-123545"
   to = aws_instance.b
 }
+
+removed {
+  from = aws_instance.c
+  lifecycle {
+    destroy = false
+  }
+}
+


### PR DESCRIPTION
As introduced in terraform 1.7.x
- https://developer.hashicorp.com/terraform/language/resources/syntax#removing-resources

'removed' block is now a valid 