### PR TITLE
Bump golangci-lint version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-go@v3
 
       - name: Set up golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.61.0
+          version: v2.7.2
           args: --timeout=3m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,21 @@
-issues:
-  exclude-dirs:
-    - pkg/configs
+version: "2"
+linters:
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - pkg/configs
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
- Run `golangci-lint migrate` to migrate .golangci.yml
- Bump golangci-lint-action's version